### PR TITLE
fix: need array, object given

### DIFF
--- a/src/Responses/PurchaseResponse.php
+++ b/src/Responses/PurchaseResponse.php
@@ -226,7 +226,7 @@ class PurchaseResponse extends AbstractResponse
             $authentication->protocol,
             $authentication->status,
             $authentication->version,
-            (isset($authentication->details)) ? $authentication->details : []
+            (isset($authentication->details)) ? (array)$authentication->details : []
         );
     }
 


### PR DESCRIPTION
Quick fix for this PHP error after Monetico response : 

```
Argument 4 passed to DansMaCulotte\Monetico\Resources\AuthenticationResource::__construct() must be of the type array, object given, called in ....../monetico-php/src/Responses/PurchaseResponse.php on line 229
```