### PR TITLE
Add empty reject reason

### DIFF
--- a/src/Responses/PurchaseResponse.php
+++ b/src/Responses/PurchaseResponse.php
@@ -121,6 +121,7 @@ class PurchaseResponse extends AbstractResponse
 
     /** @var array  */
     const REJECT_REASONS = [
+        '',
         'Appel Phonie',
         'Refus',
         'Interdit',


### PR DESCRIPTION
Some test cards return empty reason (3DS V2 Visa terminated by 27, 29, 30, and 3DS V2 Mastercard terminated by 29, 30, 31)