### PR TITLE
fix: handle error field as status value

### DIFF
--- a/src/Resources/AuthenticationResource.php
+++ b/src/Resources/AuthenticationResource.php
@@ -27,6 +27,7 @@ class AuthenticationResource
         'authentication_attempted',
         'not_enrolled',
         'disabled',
+        'error',
     ];
 
     /** @var string */

--- a/tests/AuthenticationResourceTest.php
+++ b/tests/AuthenticationResourceTest.php
@@ -228,4 +228,16 @@ class AuthenticationResourceTest extends TestCase
             ]
         );
     }
+
+    public function testAutenticationConstructWithErrorStatus()
+    {
+        $authentication = new AuthenticationResource(
+            '3DSecure',
+            'error',
+            '2.1.0',
+            []
+        );
+
+        $this->assertInstanceOf(AuthenticationResource::class, $authentication);
+    }
 }


### PR DESCRIPTION
Monetico returned to us the value `error` for `authentification.status`
field. This value is not in documented value and support told me it is
because of a non completely enrolled 3dsecure process.

I add this value to possible statuses as it should not make the validation
process fail.