### PR TITLE
Added an optional field

### DIFF
--- a/src/Requests/PurchaseRequest.php
+++ b/src/Requests/PurchaseRequest.php
@@ -195,6 +195,16 @@ class PurchaseRequest extends AbstractRequest
     }
 
     /**
+     * Change company sign region label on payment interface
+     *
+     * @param string $label New sign label content
+     */
+    public function setRegionSignLabel(string $label): void
+    {
+        $this->options['libelleMonetiqueLocalite'] = $label;
+    }
+
+    /**
      * @param BillingAddressResource $billingAddress
      */
     public function setBillingAddress(BillingAddressResource $billingAddress): void
@@ -338,6 +348,7 @@ class PurchaseRequest extends AbstractRequest
             'desactivemoyenpaiement' => $this->options['desactivemoyenpaiement'] ?? '',
             'forcesaisiecb' => $this->options['forcesaisiecb'] ?? '',
             'libelleMonetique' => $this->options['libelleMonetique'] ?? '',
+            'libelleMonetiqueLocalite' => $this->options['libelleMonetiqueLocalite'] ?? '',
         ];
     }
 

--- a/tests/PurchaseRequestTest.php
+++ b/tests/PurchaseRequestTest.php
@@ -131,6 +131,10 @@ class PurchaseRequestTest extends TestCase
         $this->assertArrayHasKey('libelleMonetique', $capture->options);
         $this->assertSame($capture->options['libelleMonetique'], 'FooBar');
 
+        $capture->setRegionSignLabel('BarBaz');
+        $this->assertArrayHasKey('libelleMonetiqueLocalite', $capture->options);
+        $this->assertSame($capture->options['libelleMonetiqueLocalite'], 'BarBaz');
+
         $capture->setDisabledPaymentWays([
             '1euro',
             '3xcb',


### PR DESCRIPTION
I added the optional field `libelleMonetiqueLocalite` to the `PurchaseRequest` to be able to customize this string.