### PR TITLE
Add PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds compatibility with PHP 8. Tests should be passing as-is on both 8.0 and 8.1.