### PR TITLE
Add new supported API version

### DIFF
--- a/src/Resources/AuthenticationResource.php
+++ b/src/Resources/AuthenticationResource.php
@@ -36,7 +36,8 @@ class AuthenticationResource
     /** @var array */
     const VERSIONS = [
         '1.0.2',
-        '2.1.0'
+        '2.1.0',
+        '2.2.0',
     ];
 
     /** @var array */


### PR DESCRIPTION
Monetico is deploying a new API version to update the 3DS protocol.

It does throw an exception for now.
> DansMaCulotte\Monetico\Exceptions\AuthenticationException : version value is invalid: 2.2.0 dans DansMaCulotte\Monetico\Exceptions\AuthenticationException::invalidVersion() (ligne 31 de /home/webapp/www/vendor/dansmaculotte/monetico-php/src/Exceptions/AuthenticationException.php).

From the Monetico support today:
> Le service dédié nous indique la solution suivante :
"Une mise à jour règlementaire de la version du protocole de sécurité 3DSecure est en cours de déploiement. Il s’agit de la version 2.2. Cette mise à jour vise à renforcer la sécurité de vos transactions et de celles de vos clients.

 